### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -31,6 +34,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {

--- a/project-board/src/main/java/com/Discipline/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/Discipline/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.Discipline.projectboard.repository;
 
 import com.Discipline.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/project-board/src/main/java/com/Discipline/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/Discipline/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.Discipline.projectboard.repository;
 
 import com.Discipline.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -27,9 +27,9 @@ spring:
     h2.console.enabled: false
     sql.init.mode: always
 
-#    data.rest:
-#      base-path: /api
-#      detection-strategy: annotated
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 
 #---
 #

--- a/project-board/src/test/java/com/Discipline/projectboard/controller/DataRestTest.java
+++ b/project-board/src/test/java/com/Discipline/projectboard/controller/DataRestTest.java
@@ -1,0 +1,35 @@
+package com.Discipline.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+  private final MockMvc mvc;
+
+  public DataRestTest(@Autowired MockMvc mvc) {
+    this.mvc = mvc;
+  }
+
+  @DisplayName("[api] 게시글 리스트 조회")
+  @Test
+  void given_when_then() throws Exception {
+    mvc.perform(get("/api/articles"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+  }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 API들의 존재 여부만 체크하게끔 통합테스트 작성

